### PR TITLE
Add HTML Character Escape Decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "mime_guess",
+ "percent-encoding",
  "rust-embed",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ chrono = "0.4.31"
 http-body = "1.0.0"
 bytes = "1.5.0"
 http-body-util = "0.1.0"
+percent-encoding = "2.3.1"
 
 [dev-dependencies]
 axum = "0.7.2"

--- a/examples/assets/with space.txt
+++ b/examples/assets/with space.txt
@@ -1,0 +1,1 @@
+This is a file to demonstrate HTML escape codes in requests.


### PR DESCRIPTION
PR closes feature #2 

As evident from tests, requests with character encoding are now translated to paths that include spaces.
Requests with spaces are rejected as invalid URIs.

Thanks for creating this project, it has saved me a lot of time!